### PR TITLE
lib: unconditionally set `-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64`

### DIFF
--- a/libsmbclient_lfs.go
+++ b/libsmbclient_lfs.go
@@ -1,0 +1,9 @@
+//go:build 386 || amd64p32 || arm || armbe || mips || mips64p32 || mips64p32le || mipsle || ppc || riscv || s390 || sparc
+// +build 386 amd64p32 arm armbe mips mips64p32 mips64p32le mipsle ppc riscv s390 sparc
+
+package libsmbclient
+
+/*
+#cgo CFLAGS: -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
+*/
+import "C"


### PR DESCRIPTION
The latest debian version of libsmbclient-dev no longer sets
the large file support cflags in libsmbclient.h [1]. This
leads to build failures on 32bit systems.

It seems to me that ideally `pkg-config --cflags smbclient` would
DTRT and return `-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64` along
with `-I/usr/include/samba-4.0`. However this is not the case.

The cgo system also does not allow running arbitrary scripts so
just calling `getconf LFS_CFLAGS` is not an option.

This commit adds a new `libsmbclient_lfs.go` file that is only
build on 386/arm and defined the needed LFS cflags.

[1] https://github.com/mvo5/libsmbclient-go/issues/10